### PR TITLE
fix: store API key in OS credential manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Right-click the tray icon → **Settings**:
 | Model | `gemini-2.5-flash` | Any Gemini model name |
 | Hotkey | `Ctrl+Shift+R` | Click **Record** to change |
 
-Config is stored in `%APPDATA%\Retext\config.json`.
+Config is stored in `%APPDATA%\Retext\config.json`. The API key is stored securely in Windows Credential Manager.
 
 ## Build from source
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "google-genai>=1.0.0",
     "pystray>=0.19.5",
     "Pillow>=10.0.0",
+    "keyring>=25.0.0",
 ]
 
 [project.scripts]

--- a/src/rewrite/config.py
+++ b/src/rewrite/config.py
@@ -1,14 +1,21 @@
-"""Configuration management — JSON config stored in %APPDATA%/Retext/."""
+"""Configuration management — JSON config + OS credential store."""
 
 from __future__ import annotations
 
 import json
+import logging
 import os
 from pathlib import Path
 
+import keyring
+
+log = logging.getLogger(__name__)
+
+SERVICE_NAME = "retext"
+KEY_ACCOUNT = "gemini_api_key"
+
 DEFAULT_CONFIG: dict = {
     "hotkey": "ctrl+alt+r",
-    "gemini_api_key": "",
     "gemini_model": "gemini-2.5-flash",
 }
 
@@ -28,19 +35,79 @@ def get_config_path() -> Path:
     return get_config_dir() / "config.json"
 
 
+# ------------------------------------------------------------------
+# API key — stored in OS credential manager via keyring
+# ------------------------------------------------------------------
+
+
+def get_api_key() -> str:
+    """Retrieve the Gemini API key from the OS credential store."""
+    return keyring.get_password(SERVICE_NAME, KEY_ACCOUNT) or ""
+
+
+def set_api_key(api_key: str) -> None:
+    """Store the Gemini API key in the OS credential store."""
+    if api_key:
+        keyring.set_password(SERVICE_NAME, KEY_ACCOUNT, api_key)
+    else:
+        with _suppress_keyring_errors():
+            keyring.delete_password(SERVICE_NAME, KEY_ACCOUNT)
+
+
+def _suppress_keyring_errors():
+    """Context manager that swallows keyring errors (e.g. deleting a missing key)."""
+    import contextlib
+    return contextlib.suppress(keyring.errors.PasswordDeleteError)
+
+
+# ------------------------------------------------------------------
+# General config — everything except the API key
+# ------------------------------------------------------------------
+
+
 def load_config() -> dict:
-    """Load config from disk, merging with defaults so new keys always exist."""
+    """Load config from disk, merging with defaults so new keys always exist.
+
+    The API key is read from the OS credential store and injected into the
+    returned dict for backward-compatible consumption by the rest of the app.
+    """
     path = get_config_path()
     config = dict(DEFAULT_CONFIG)
     if path.exists():
         with path.open("r", encoding="utf-8") as f:
             stored = json.load(f)
+
+        # Migrate: move plaintext API key to credential store
+        if "gemini_api_key" in stored:
+            plaintext_key = stored.pop("gemini_api_key", "")
+            if plaintext_key and not get_api_key():
+                log.info("Migrating API key from config.json to credential store")
+                set_api_key(plaintext_key)
+            # Re-save config.json without the key
+            _write_json(path, stored)
+
         config.update(stored)
+
+    # Inject the key from the credential store so callers see it in the dict
+    config["gemini_api_key"] = get_api_key()
     return config
 
 
 def save_config(config: dict) -> None:
-    """Write config dict to disk as formatted JSON."""
+    """Write config dict to disk. The API key goes to the credential store."""
+    api_key = config.pop("gemini_api_key", None)
+    if api_key is not None:
+        set_api_key(api_key)
+
     path = get_config_path()
+    _write_json(path, config)
+
+    # Restore the key in the dict so the caller's reference stays complete
+    if api_key is not None:
+        config["gemini_api_key"] = api_key
+
+
+def _write_json(path: Path, data: dict) -> None:
+    """Write a dict to a JSON file."""
     with path.open("w", encoding="utf-8") as f:
-        json.dump(config, f, indent=2, ensure_ascii=False)
+        json.dump(data, f, indent=2, ensure_ascii=False)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,8 +5,29 @@ import pytest
 
 @pytest.fixture
 def temp_config_dir(tmp_path):
-    """Provide a temp directory for config files."""
-    with patch("rewrite.config.get_config_dir", return_value=tmp_path):
+    """Provide a temp directory for config files and mock keyring."""
+    store: dict[str, str] = {}
+
+    def _get(service: str, account: str) -> str | None:
+        return store.get(f"{service}:{account}")
+
+    def _set(service: str, account: str, password: str) -> None:
+        store[f"{service}:{account}"] = password
+
+    def _delete(service: str, account: str) -> None:
+        key = f"{service}:{account}"
+        if key in store:
+            del store[key]
+        else:
+            import keyring.errors
+            raise keyring.errors.PasswordDeleteError(f"{key} not found")
+
+    with (
+        patch("rewrite.config.get_config_dir", return_value=tmp_path),
+        patch("rewrite.config.keyring.get_password", side_effect=_get),
+        patch("rewrite.config.keyring.set_password", side_effect=_set),
+        patch("rewrite.config.keyring.delete_password", side_effect=_delete),
+    ):
         yield tmp_path
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,7 +5,8 @@ from rewrite.config import DEFAULT_CONFIG, load_config, save_config
 
 def test_default_config_returned_when_no_file(temp_config_dir):
     config = load_config()
-    assert config == DEFAULT_CONFIG
+    expected = {**DEFAULT_CONFIG, "gemini_api_key": ""}
+    assert config == expected
 
 
 def test_save_and_load_roundtrip(temp_config_dir, sample_config):
@@ -40,4 +41,36 @@ def test_save_creates_file(temp_config_dir, sample_config):
     config_file = temp_config_dir / "config.json"
     assert config_file.exists()
     data = json.loads(config_file.read_text())
-    assert data["gemini_api_key"] == "test-gemini-key"
+    # API key should NOT be in the JSON file
+    assert "gemini_api_key" not in data
+
+
+def test_api_key_not_in_json(temp_config_dir, sample_config):
+    """API key must be stored in keyring, not in config.json."""
+    save_config(sample_config)
+    config_file = temp_config_dir / "config.json"
+    data = json.loads(config_file.read_text())
+    assert "gemini_api_key" not in data
+
+
+def test_api_key_survives_roundtrip(temp_config_dir):
+    """API key set via save_config should come back via load_config."""
+    save_config({"gemini_api_key": "secret-key-123"})
+    loaded = load_config()
+    assert loaded["gemini_api_key"] == "secret-key-123"
+
+
+def test_migrate_plaintext_key(temp_config_dir):
+    """If config.json contains a plaintext API key, it gets migrated to keyring."""
+    config_file = temp_config_dir / "config.json"
+    config_file.write_text(json.dumps({
+        "hotkey": "ctrl+alt+r",
+        "gemini_api_key": "old-plaintext-key",
+        "gemini_model": "gemini-2.5-flash",
+    }))
+    loaded = load_config()
+    # Key should be migrated
+    assert loaded["gemini_api_key"] == "old-plaintext-key"
+    # JSON file should no longer contain the key
+    data = json.loads(config_file.read_text())
+    assert "gemini_api_key" not in data


### PR DESCRIPTION
## Summary

Fixes #2 — API key was stored as plaintext in `config.json`.

- Uses `keyring` library (backed by Windows Credential Manager) to store the Gemini API key securely
- API key is no longer written to `config.json`
- Automatic migration: existing plaintext keys are moved to the credential store on first load, then stripped from the JSON file
- 8 config tests covering roundtrip, migration, and ensuring the key never leaks to disk

## Test plan

- [x] All 23 existing tests pass
- [x] New tests verify key is never in JSON, survives roundtrip, and migrates from plaintext
- [ ] Manual: run app, set API key in Settings, verify it appears in Windows Credential Manager (not in `%APPDATA%\Retext\config.json`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)