### PR TITLE
ci: auto-build Retext.exe on release tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,39 @@
+name: Build & Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: |
+          pip install -e .
+          pip install pyinstaller
+
+      - name: Build exe
+        run: >
+          pyinstaller
+          --onefile --windowed
+          --name Retext
+          --icon assets/icon.ico
+          --add-data "assets;assets"
+          src/rewrite/main.py
+
+      - name: Upload exe to release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload ${{ github.ref_name }} dist/Retext.exe --clobber


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that automatically builds `Retext.exe` whenever a `v*` tag is pushed.

- Runs on `windows-latest` with Python 3.12
- Installs deps, builds with PyInstaller, uploads the exe to the matching GitHub release
- No more manual builds — just `git tag v0.2.0 && git push --tags`

## Test plan

- [ ] Merge, then create a test tag to verify the workflow runs and uploads the exe

🤖 Generated with [Claude Code](https://claude.com/claude-code)