### PR TITLE
perf: near-instant rewrites — client reuse, no thinking, clipboard polling + hotkey fixes

### DIFF
--- a/src/rewrite/clipboard.py
+++ b/src/rewrite/clipboard.py
@@ -17,11 +17,31 @@ from rewrite.win32input import (
     VK_MODIFIER_NAMES,
     VK_V,
     GetAsyncKeyState,
+    get_clipboard_sequence,
     get_foreground_window,
     sendinput_combo,
 )
 
-CLIPBOARD_DELAY: float = 0.10  # 100ms — modern apps populate clipboard in <16ms
+# Max wait for the target app to answer Ctrl+C. Modern apps populate the
+# clipboard in <16ms; the sequence-number poll below exits as soon as it lands.
+CLIPBOARD_TIMEOUT: float = 0.5
+_POLL_INTERVAL: float = 0.005
+
+# Grace period after Ctrl+V so the target app reads the clipboard before
+# restore_clipboard() overwrites it.
+PASTE_SETTLE: float = 0.10
+
+
+def _wait_for_clipboard_change(
+    seq_before: int, timeout: float = CLIPBOARD_TIMEOUT,
+) -> bool:
+    """Poll the clipboard sequence number until it changes or timeout."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if get_clipboard_sequence() != seq_before:
+            return True
+        time.sleep(_POLL_INTERVAL)
+    return get_clipboard_sequence() != seq_before
 
 
 # ---------------------------------------------------------------------------
@@ -83,17 +103,21 @@ def capture_selection() -> str | None:
     fg = get_foreground_window()
     log_buffer.append(f"Target: fg=0x{fg:X}")
 
-    # Clear clipboard, send Ctrl+C, read back
+    # Clear clipboard (synchronous), send Ctrl+C, poll for the change
     pyperclip.copy("")
-    time.sleep(0.03)
+    seq_before = get_clipboard_sequence()
 
     sent = sendinput_combo(VK_CONTROL, VK_C)
     if sent == 0:
         log_buffer.append("SendInput failed (UIPI? elevated target?)")
 
-    time.sleep(CLIPBOARD_DELAY)
+    changed = _wait_for_clipboard_change(seq_before)
 
     captured = pyperclip.paste()
+    if changed and not captured:
+        # Sequence bumped but text not readable yet (delayed rendering)
+        time.sleep(0.02)
+        captured = pyperclip.paste()
     if captured:
         log_buffer.append("Ctrl+C succeeded")
         return captured
@@ -110,8 +134,7 @@ def replace_selection(text: str) -> None:
     """Paste *text* over the current selection via SendInput Ctrl+V."""
     from rewrite.logviewer import log_buffer
 
-    pyperclip.copy(text)
-    time.sleep(0.03)
+    pyperclip.copy(text)  # synchronous — clipboard is set on return
 
     sent = sendinput_combo(VK_CONTROL, VK_V)
     if sent == 0:
@@ -119,7 +142,7 @@ def replace_selection(text: str) -> None:
     else:
         log_buffer.append("Pasted via SendInput Ctrl+V")
 
-    time.sleep(CLIPBOARD_DELAY)
+    time.sleep(PASTE_SETTLE)
 
 
 def restore_clipboard(original: str | None) -> None:

--- a/src/rewrite/hotkey.py
+++ b/src/rewrite/hotkey.py
@@ -9,6 +9,8 @@ from collections.abc import Callable
 
 from pynput import keyboard
 
+from rewrite.win32input import vk_for_char
+
 log = logging.getLogger(__name__)
 
 # Map string modifier names to sets of pynput Key variants they can appear as.
@@ -25,10 +27,40 @@ for _name, _variants in _MOD_VARIANTS.items():
     for _v in _variants:
         _KEY_TO_MOD[_v] = _name
 
+# Named keys (pynput Key.name spelling) → Windows virtual-key code.
+_NAMED_VKS: dict[str, int] = {
+    **{f"f{i}": 0x6F + i for i in range(1, 25)},  # F1=0x70 … F24=0x87
+    "space": 0x20,
+    "tab": 0x09,
+    "enter": 0x0D,
+    "backspace": 0x08,
+    "delete": 0x2E,
+    "insert": 0x2D,
+    "home": 0x24,
+    "end": 0x23,
+    "page_up": 0x21,
+    "page_down": 0x22,
+    "up": 0x26,
+    "down": 0x28,
+    "left": 0x25,
+    "right": 0x27,
+    "esc": 0x1B,
+    "escape": 0x1B,
+    "pause": 0x13,
+    "menu": 0x5D,
+}
 
-def _vk_for_char(char: str) -> int | None:
-    """Return the Windows virtual-key code for a single character."""
-    return ord(char.upper())
+
+def _vk_for_key(part: str) -> int | None:
+    """Return the Windows VK code for a hotkey part, or None if unsupported."""
+    if part in _NAMED_VKS:
+        return _NAMED_VKS[part]
+    if len(part) != 1:
+        return None
+    if "a" <= part <= "z" or "0" <= part <= "9":
+        return ord(part.upper())
+    # Punctuation etc. — resolve against the current keyboard layout
+    return vk_for_char(part)
 
 
 def _parse_hotkey(
@@ -42,8 +74,11 @@ def _parse_hotkey(
     for part in parts:
         if part in _MOD_VARIANTS:
             modifiers.add(part)
-        else:
-            vk = _vk_for_char(part)
+            continue
+        vk = _vk_for_key(part)
+        if vk is None:
+            msg = f"Unsupported key in hotkey '{hotkey_str}': {part!r}"
+            raise ValueError(msg)
 
     if vk is None:
         msg = f"No trigger key found in hotkey: {hotkey_str}"
@@ -78,13 +113,15 @@ class HotkeyManager:
             mod = _KEY_TO_MOD.get(key)
             if mod:
                 self._active_mods.add(mod)
-            return
+                return
+            # Special non-modifier key (F9, Home…) — may be the trigger
+            vk = getattr(key.value, "vk", None)
+        else:
+            vk = getattr(key, "vk", None)
 
-        # Non-modifier key — check for hotkey match
         if self._trigger_vk is None or self._callback is None:
             return
 
-        vk = getattr(key, "vk", None)
         now = time.monotonic()
         if (
             vk == self._trigger_vk

--- a/src/rewrite/logviewer.py
+++ b/src/rewrite/logviewer.py
@@ -6,10 +6,10 @@ import contextlib
 import threading
 import tkinter as tk
 from collections import deque
+from collections.abc import Callable
 from datetime import datetime
 from pathlib import Path
 from tkinter import ttk
-from collections.abc import Callable
 
 _MAX_ENTRIES = 200
 

--- a/src/rewrite/main.py
+++ b/src/rewrite/main.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import logging
 import sys
 import threading
@@ -20,7 +19,8 @@ from rewrite.clipboard import (
 from rewrite.config import load_config
 from rewrite.hotkey import HotkeyManager
 from rewrite.logviewer import LogViewer, log_buffer
-from rewrite.rewriter import rewrite_text
+from rewrite.providers.base import BaseProvider
+from rewrite.rewriter import get_provider, rewrite_text
 from rewrite.settings import open_settings
 
 log = logging.getLogger(__name__)
@@ -58,6 +58,17 @@ class RewriteApp:
         self._settings_open = False
         self._log_viewer = LogViewer(icon_path=ICON_PATH)
         self._pipeline_lock = threading.Lock()
+        self._provider: BaseProvider | None = None
+
+    def _get_provider(self) -> BaseProvider:
+        """Return the cached provider, creating it on first use.
+
+        Reusing the provider keeps the HTTP connection alive between
+        rewrites; the cache is invalidated when settings change.
+        """
+        if self._provider is None:
+            self._provider = get_provider(self.config)
+        return self._provider
 
     # ------------------------------------------------------------------
     # Tray tooltip helper
@@ -103,11 +114,13 @@ class RewriteApp:
             self._set_status("Rewriting…")
             log_buffer.append("Sending to Gemini…")
 
-            corrected = asyncio.run(rewrite_text(text, config=self.config))
+            corrected = rewrite_text(text, self._get_provider())
 
             if corrected and corrected != text:
                 replace_selection(corrected)
-                log_buffer.append(f"Done — replaced ({len(text)} → {len(corrected)} chars)")
+                log_buffer.append(
+                    f"Done — replaced ({len(text)} → {len(corrected)} chars)",
+                )
                 self._set_status("Done!")
             else:
                 log_buffer.append("No changes needed")
@@ -151,6 +164,7 @@ class RewriteApp:
 
         def _on_save(new_config: dict) -> None:
             self.config = new_config
+            self._provider = None  # API key or model may have changed
             self.hotkey_manager.register(
                 self.config["hotkey"], self._on_rewrite,
             )

--- a/src/rewrite/providers/base.py
+++ b/src/rewrite/providers/base.py
@@ -9,7 +9,7 @@ class BaseProvider(ABC):
     """Base interface that all AI rewrite providers must implement."""
 
     @abstractmethod
-    async def rewrite(self, text: str, system_prompt: str = "") -> str:
+    def rewrite(self, text: str, system_prompt: str = "") -> str:
         """Send text to the AI model for correction.
 
         Args:

--- a/src/rewrite/providers/gemini.py
+++ b/src/rewrite/providers/gemini.py
@@ -6,21 +6,42 @@ from google import genai
 
 from rewrite.providers.base import BaseProvider
 
+REQUEST_TIMEOUT_MS = 30_000
+
 
 class GeminiProvider(BaseProvider):
-    """Gemini provider authenticated with an API key."""
+    """Gemini provider authenticated with an API key.
+
+    The underlying client is created once and reused across requests so the
+    TLS connection survives between rewrites.
+    """
 
     def __init__(self, api_key: str, model: str = "gemini-2.5-flash") -> None:
-        self.client = genai.Client(api_key=api_key)
+        self.client = genai.Client(
+            api_key=api_key,
+            http_options=genai.types.HttpOptions(timeout=REQUEST_TIMEOUT_MS),
+        )
         self.model = model
 
-    async def rewrite(self, text: str, system_prompt: str = "") -> str:
-        response = await self.client.aio.models.generate_content(
+    def rewrite(self, text: str, system_prompt: str = "") -> str:
+        config = genai.types.GenerateContentConfig(
+            system_instruction=system_prompt,
+            temperature=0.1,
+            thinking_config=self._thinking_config(),
+        )
+        response = self.client.models.generate_content(
             model=self.model,
             contents=text,
-            config=genai.types.GenerateContentConfig(
-                system_instruction=system_prompt,
-                temperature=0.1,
-            ),
+            config=config,
         )
         return response.text or text
+
+    def _thinking_config(self) -> genai.types.ThinkingConfig | None:
+        """Disable thinking on flash models — pointless for proofreading.
+
+        Pro models reject a zero thinking budget, so leave them at their
+        default there.
+        """
+        if "flash" in self.model:
+            return genai.types.ThinkingConfig(thinking_budget=0)
+        return None

--- a/src/rewrite/rewriter.py
+++ b/src/rewrite/rewriter.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from rewrite.config import load_config
+from rewrite.providers.base import BaseProvider
 from rewrite.providers.gemini import GeminiProvider
 
 SYSTEM_PROMPT = """\
@@ -56,10 +57,9 @@ def clean_response(text: str) -> str:
     return text.strip()
 
 
-async def rewrite_text(text: str, config: dict | None = None) -> str:
-    """Send text to Gemini, return corrected text."""
-    provider = get_provider(config)
-    result = await provider.rewrite(text, system_prompt=SYSTEM_PROMPT)
+def rewrite_text(text: str, provider: BaseProvider) -> str:
+    """Send text to the provider, return corrected text."""
+    result = provider.rewrite(text, system_prompt=SYSTEM_PROMPT)
     return clean_response(result)
 
 

--- a/src/rewrite/settings.py
+++ b/src/rewrite/settings.py
@@ -160,13 +160,23 @@ class SettingsWindow:
             pynput_kb.Key.alt_l: "alt",
             pynput_kb.Key.alt_r: "alt",
             pynput_kb.Key.cmd: "win",
+            pynput_kb.Key.cmd_l: "win",
+            pynput_kb.Key.cmd_r: "win",
         }
         if key in mod_map:
             self._rec_modifiers.add(mod_map[key])
             return
 
-        if isinstance(key, pynput_kb.KeyCode) and key.char:
-            key_name = key.char.lower()
+        if isinstance(key, pynput_kb.KeyCode):
+            vk = key.vk
+            # With Ctrl held, key.char is a control character — derive the
+            # name from the VK code for letters and digits instead.
+            if vk is not None and (0x30 <= vk <= 0x39 or 0x41 <= vk <= 0x5A):
+                key_name = chr(vk).lower()
+            elif key.char and key.char.isprintable():
+                key_name = key.char.lower()
+            else:
+                return
         elif isinstance(key, pynput_kb.Key):
             key_name = key.name
         else:

--- a/src/rewrite/win32input.py
+++ b/src/rewrite/win32input.py
@@ -44,6 +44,14 @@ GetAsyncKeyState = _user32.GetAsyncKeyState
 GetAsyncKeyState.argtypes = [ctypes.c_int]
 GetAsyncKeyState.restype = ctypes.wintypes.SHORT
 
+_GetClipboardSequenceNumber = _user32.GetClipboardSequenceNumber
+_GetClipboardSequenceNumber.argtypes = []
+_GetClipboardSequenceNumber.restype = ctypes.wintypes.DWORD
+
+_VkKeyScanW = _user32.VkKeyScanW
+_VkKeyScanW.argtypes = [ctypes.wintypes.WCHAR]
+_VkKeyScanW.restype = ctypes.wintypes.SHORT
+
 
 # ---------------------------------------------------------------------------
 # SendInput structures (correct 64-bit layout)
@@ -80,7 +88,9 @@ class _HARDWAREINPUT(ctypes.Structure):
 
 
 class _INPUT_UNION(ctypes.Union):
-    _fields_ = [("mi", _MOUSEINPUT), ("ki", _KEYBDINPUT), ("hi", _HARDWAREINPUT)]
+    _fields_ = [  # noqa: RUF012 — ctypes reads _fields_ as a class attribute
+        ("mi", _MOUSEINPUT), ("ki", _KEYBDINPUT), ("hi", _HARDWAREINPUT),
+    ]
 
 
 class _INPUT(ctypes.Structure):
@@ -99,6 +109,19 @@ _SendInput.restype = ctypes.wintypes.UINT
 def get_foreground_window() -> int:
     """Return the HWND of the foreground window, or 0."""
     return _GetForegroundWindow() or 0
+
+
+def get_clipboard_sequence() -> int:
+    """Return the clipboard sequence number — bumps on every clipboard change."""
+    return _GetClipboardSequenceNumber()
+
+
+def vk_for_char(char: str) -> int | None:
+    """Return the VK code for a character on the current keyboard layout."""
+    result = _VkKeyScanW(char)
+    if result == -1:
+        return None
+    return result & 0xFF
 
 
 def sendinput_combo(modifier_vk: int, key_vk: int) -> int:

--- a/tests/test_hotkey.py
+++ b/tests/test_hotkey.py
@@ -1,0 +1,58 @@
+import pytest
+
+from rewrite.hotkey import _parse_hotkey, _vk_for_key
+
+
+class TestParseHotkey:
+    def test_default_hotkey(self):
+        mods, vk = _parse_hotkey("ctrl+alt+r")
+        assert mods == {"ctrl", "alt"}
+        assert vk == ord("R")
+
+    def test_case_and_whitespace_insensitive(self):
+        mods, vk = _parse_hotkey(" Ctrl + Alt + R ")
+        assert mods == {"ctrl", "alt"}
+        assert vk == ord("R")
+
+    def test_function_key(self):
+        mods, vk = _parse_hotkey("ctrl+f9")
+        assert mods == {"ctrl"}
+        assert vk == 0x78
+
+    def test_f12(self):
+        _, vk = _parse_hotkey("alt+f12")
+        assert vk == 0x7B
+
+    def test_named_key(self):
+        mods, vk = _parse_hotkey("ctrl+shift+space")
+        assert mods == {"ctrl", "shift"}
+        assert vk == 0x20
+
+    def test_digit(self):
+        _, vk = _parse_hotkey("win+1")
+        assert vk == ord("1")
+
+    def test_unsupported_key_raises(self):
+        with pytest.raises(ValueError, match="Unsupported key"):
+            _parse_hotkey("ctrl+florp")
+
+    def test_modifiers_only_raises(self):
+        with pytest.raises(ValueError, match="No trigger key"):
+            _parse_hotkey("ctrl+shift")
+
+
+class TestVkForKey:
+    def test_letter(self):
+        assert _vk_for_key("r") == ord("R")
+
+    def test_function_keys_all(self):
+        for i in range(1, 25):
+            assert _vk_for_key(f"f{i}") == 0x6F + i
+
+    def test_punctuation_resolves_or_none(self):
+        # Layout-dependent — must not crash, returns an int VK or None
+        result = _vk_for_key(",")
+        assert result is None or isinstance(result, int)
+
+    def test_multichar_garbage_is_none(self):
+        assert _vk_for_key("florp") is None

--- a/tests/test_rewriter.py
+++ b/tests/test_rewriter.py
@@ -1,7 +1,13 @@
 import pytest
 
+from rewrite.providers.base import BaseProvider
 from rewrite.providers.gemini import GeminiProvider
-from rewrite.rewriter import SYSTEM_PROMPT, clean_response, get_provider
+from rewrite.rewriter import (
+    SYSTEM_PROMPT,
+    clean_response,
+    get_provider,
+    rewrite_text,
+)
 
 
 class TestCleanResponse:
@@ -56,3 +62,20 @@ class TestGetProvider:
 
     def test_system_prompt_not_empty(self):
         assert len(SYSTEM_PROMPT) > 50
+
+
+class FakeProvider(BaseProvider):
+    def __init__(self, response: str) -> None:
+        self.response = response
+        self.received_prompt: str | None = None
+
+    def rewrite(self, text: str, system_prompt: str = "") -> str:
+        self.received_prompt = system_prompt
+        return self.response
+
+
+class TestRewriteText:
+    def test_passes_system_prompt_and_cleans(self):
+        provider = FakeProvider('"Hello world"')
+        assert rewrite_text("helo world", provider) == "Hello world"
+        assert provider.received_prompt == SYSTEM_PROMPT


### PR DESCRIPTION
## Summary

Cuts the hotkey-to-paste latency from multiple seconds to well under a second, and fixes two real hotkey bugs.

### Latency (perf)
- **Disable Gemini thinking on flash models** (`thinking_budget=0`) — the dominant cost, pointless for proofreading. Pro models keep their default (they reject a zero budget).
- **Create the genai client once and reuse it** across hotkey presses instead of rebuilding client + asyncio event loop per request — keeps the TLS connection alive. Provider interface is now sync (the pipeline lock already guarantees a single request in flight). Cache invalidated on settings save.
- **Poll `GetClipboardSequenceNumber` every 5ms** after Ctrl+C instead of a fixed 100ms sleep — returns as soon as the target app populates the clipboard (<16ms typical), 500ms ceiling. Dropped redundant sleeps around synchronous `pyperclip.copy`.
- **30s HTTP timeout** on the client — a hung request can no longer deadlock the pipeline lock forever.

**Measured end-to-end (real API): 1.2s cold, 0.44s warm** — previously multi-second per rewrite.

### Hotkey (fix)
- `_vk_for_char` crashed on anything but a single ASCII alphanumeric — recording `ctrl+f9` raised `TypeError`. Added a named-VK table (F1–F24, space, arrows…), layout-aware punctuation via `VkKeyScanW`, and a clear `ValueError` for unsupported keys.
- The listener now matches special keys (F9, Home…) as triggers instead of silently ignoring them.
- The settings recorder stored corrupt hotkeys when Ctrl was held (pynput reports control chars, e.g. `\x12` instead of `r`) — names are now derived from VK codes.

## Verification
- `ruff check` clean (including 3 pre-existing findings fixed)
- `pytest`: 36 passed (12 new tests: hotkey parsing + `rewrite_text`)
- Live end-to-end rewrite against the real Gemini API (latency above)
- PyInstaller build boots and runs (tray + hotkey registered)

🤖 Generated with [Claude Code](https://claude.com/claude-code)