### PR TITLE
ci: create the GitHub release on the fly if the tag has none

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,4 +36,7 @@ jobs:
       - name: Upload exe to release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload ${{ github.ref_name }} dist/Retext.exe --clobber
+        # A bare `git push --tags` has no GitHub release yet — create it on the fly.
+        run: |
+          gh release view ${{ github.ref_name }} 2>$null || gh release create ${{ github.ref_name }} --generate-notes
+          gh release upload ${{ github.ref_name }} dist/Retext.exe --clobber


### PR DESCRIPTION
## Summary

`gh release upload` fails when a `v*` tag is pushed without an existing GitHub release (bare `git push --tags`). Guard with `gh release view || gh release create --generate-notes` so the workflow handles both flows:

- release created first in the GitHub UI (tag comes with it) — unchanged
- bare tag push — release is now created on the fly with generated notes

One-line behavioral change, `--clobber` upload untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)